### PR TITLE
Link points to the wrong repo

### DIFF
--- a/docs/scripting/rubyScripting.md
+++ b/docs/scripting/rubyScripting.md
@@ -15,7 +15,7 @@
 
 ## What you need
 
-You can download the decompiler and compiler with pre built mruby binaries from [here](../../tools/pakScriptTools).
+You can download the decompiler and compiler with pre built mruby binaries from [here](https://github.com/ArthurHeitmann/MrubyDecompiler).
 
 Or optionally get the [auto rebuild tool](https://github.com/ArthurHeitmann/NierAutoRebuild).
 


### PR DESCRIPTION
I believe the link in the 18th line should point to the MrubyDecompiler repo instead of the pakScriptTools repo.