### PR TITLE
Fix hangs with non *.yax

### DIFF
--- a/tools/pakScriptTools/yaxToXml.py
+++ b/tools/pakScriptTools/yaxToXml.py
@@ -130,5 +130,11 @@ def yaxToXml(yaxFile: str, outFile: str|None = None):
 if __name__ == "__main__":
 	yaxFiles = sys.argv[1:]
 	for yaxFile in yaxFiles:
+		if not "yax" in yaxFile:
+			if len(yaxFiles) > 1:
+				#To allow manually processing singular non *.yax files
+				print(yaxFile , " is not a *.yax file. Skipping...")
+				continue
+		
 		yaxToXml(yaxFile)
 		print(f"Converted {yaxFile} to xml")


### PR DESCRIPTION
Hangs when non .yax files are fed in before the .yax files.
pakInfo.json sometimes causes this behaviour.
Dragging said files one by one will bypass the check.